### PR TITLE
Add search index data

### DIFF
--- a/search_data.json
+++ b/search_data.json
@@ -1,0 +1,50 @@
+---
+layout: null
+---
+{
+  {% for item_hash in data.resource %}
+    {% assign object = item_hash[1] %}
+    {% assign id = item_hash[0] %}
+    {% assign collection_id = object.uri | split:'/' | last %}
+    {% assign subjects = "" | split: ',' %}
+    {% assign agents = "" | split: ',' %}
+    {% assign dates = "" | split: ',' %}
+
+    {% for date in object.dates %}
+      {% assign dates = dates | push: date.expression %}
+    {% endfor %}
+
+    {% for subject in object.subjects %}
+      {% capture subject_id %}{{ subject.ref | split: '/' | last }}{% endcapture %}
+      {% assign obj = site.data.subject[subject_id] %}
+      {% assign subjects = subjects | push: obj.title %}
+    {% endfor %}
+
+    {% for agent in object.linked_agents %}
+      {% capture agent_id %}{{ agent.ref | split: '/' | last }}{% endcapture %}
+      {% if agent.ref contains "corporate_entities" %}
+        {% assign agent_data = site.data.agent_corporate_entity[agent_id] %}
+        {% assign agents = agents | push: agent_data.title %}
+      {% elsif agent.ref contains "people" %}
+        {% assign agent_data = site.data.agent_person[agent_id] %}
+        {% assign agents = agents | push: agent_data.title %}
+      {% endif %}
+    {% endfor %}
+
+    {% for instance in object.instances %}
+      {%- capture top_container_id -%}
+        {{ instance.sub_container.top_container.ref | split: '/' | last }}
+      {%- endcapture -%}
+      {% assign obj = site.data.top_container[top_container_id] %}
+    {% endfor %}
+
+    "resource/{{id}}": {
+      "href": "resource/{{id}}",
+      "title": "{{object.title | escape | strip_newlines | remove: '\'}}",
+      "url": "{{site.url}}/resource/{{id}}",
+      "dates": "{{ dates }}",
+      "agents": "{{ agents }}",
+      "subjects": "{{ subjects }}",
+    }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+}


### PR DESCRIPTION
Adds search index data.

Currently a little stuck on how to deal with notes in a systematic manner. There are a huge variety, and I'm not sure we'd need all of them. I figure Publication and ISBN maybe? Additionally, I'm not quite sure how to capture them with the proper title/content as for the others, I'm basically just writing strings to an array in liquid.

Additionally, a little stumped on how to work with top containers. We really only want these for the call number, which is in the indicator. Some library resources have multiple top containers, but not all of them have the call number (I think), and some are multiple top containers with the same call number... See https://dimes.rockarch.org/xtf/view?docId=mods/LI03963/LI03963.xml;query=;chunk.id=headerlink;brand=default and https://dimes.rockarch.org/xtf/view?docId=mods/LI07343/LI07343.xml;query=;chunk.id=headerlink;brand=default as examples.

Some guidance on whether what I have is the correct approach for this, and how to handle top containers/notes would be appreciated.