### PR TITLE
Add search index data

### DIFF
--- a/_data/top_container/187379.json
+++ b/_data/top_container/187379.json
@@ -1,0 +1,30 @@
+{
+  "lock_version": 2,
+  "barcode": "00000000026735",
+  "indicator": "379 GEN",
+  "created_by": "sgandhi",
+  "last_modified_by": "sgandhi",
+  "create_time": "2019-06-07T21:25:26Z",
+  "system_mtime": "2019-12-04T14:42:46Z",
+  "user_mtime": "2019-06-07T21:25:26Z",
+  "type": "item",
+  "jsonmodel_type": "top_container",
+  "active_restrictions": [],
+  "container_locations": [],
+  "series": [],
+  "collection": [
+    {
+      "ref": "/repositories/2/resources/12924",
+      "identifier": "LI10717",
+      "display_string": "General Education Board: Review and final report 1902-1964."
+    }
+  ],
+  "uri": "/repositories/2/top_containers/187379",
+  "repository": {
+    "ref": "/repositories/2"
+  },
+  "restricted": false,
+  "is_linked_to_published_record": true,
+  "display_string": "Item 379 GEN: [00000000026735]",
+  "long_display_string": "LI10717, Item 379 GEN [00000000026735]"
+}

--- a/_data/top_container/187380.json
+++ b/_data/top_container/187380.json
@@ -1,0 +1,30 @@
+{
+  "lock_version": 2,
+  "barcode": "00000000026736",
+  "indicator": "379 GEN c.2",
+  "created_by": "sgandhi",
+  "last_modified_by": "sgandhi",
+  "create_time": "2019-06-07T21:26:51Z",
+  "system_mtime": "2019-12-04T14:42:46Z",
+  "user_mtime": "2019-06-07T21:26:51Z",
+  "type": "item",
+  "jsonmodel_type": "top_container",
+  "active_restrictions": [],
+  "container_locations": [],
+  "series": [],
+  "collection": [
+    {
+      "ref": "/repositories/2/resources/12924",
+      "identifier": "LI10717",
+      "display_string": "General Education Board: Review and final report 1902-1964."
+    }
+  ],
+  "uri": "/repositories/2/top_containers/187380",
+  "repository": {
+    "ref": "/repositories/2"
+  },
+  "restricted": false,
+  "is_linked_to_published_record": true,
+  "display_string": "Item 379 GEN c.2: [00000000026736]",
+  "long_display_string": "LI10717, Item 379 GEN c.2 [00000000026736]"
+}

--- a/_data/top_container/187381.json
+++ b/_data/top_container/187381.json
@@ -1,0 +1,30 @@
+{
+  "lock_version": 2,
+  "barcode": "00000000026737",
+  "indicator": "379 GEN c.3",
+  "created_by": "sgandhi",
+  "last_modified_by": "sgandhi",
+  "create_time": "2019-06-07T21:28:10Z",
+  "system_mtime": "2019-12-04T14:42:46Z",
+  "user_mtime": "2019-06-07T21:28:10Z",
+  "type": "item",
+  "jsonmodel_type": "top_container",
+  "active_restrictions": [],
+  "container_locations": [],
+  "series": [],
+  "collection": [
+    {
+      "ref": "/repositories/2/resources/12924",
+      "identifier": "LI10717",
+      "display_string": "General Education Board: Review and final report 1902-1964."
+    }
+  ],
+  "uri": "/repositories/2/top_containers/187381",
+  "repository": {
+    "ref": "/repositories/2"
+  },
+  "restricted": false,
+  "is_linked_to_published_record": true,
+  "display_string": "Item 379 GEN c.3: [00000000026737]",
+  "long_display_string": "LI10717, Item 379 GEN c.3 [00000000026737]"
+}

--- a/_includes/call_numbers.html
+++ b/_includes/call_numbers.html
@@ -1,0 +1,8 @@
+{%- assign call_numbers = "" | split: ',' -%}
+{% for instance in object.instances %}
+  {%- capture top_container_id -%}
+    {{ instance.sub_container.top_container.ref | split: '/' | last }}
+  {%- endcapture -%}
+  {%- assign obj = site.data.top_container[top_container_id] -%}
+  {%- assign call_numbers = call_numbers | push: obj.indicator -%}
+{%- endfor -%}

--- a/_includes/note_content.html
+++ b/_includes/note_content.html
@@ -1,0 +1,12 @@
+{%- case {{note.jsonmodel_type}} -%}
+{%- when 'note_multipart' -%}
+  {%- for subnote in note.subnotes -%}
+    {%- if subnote.jsonmodel_type == 'note_text' -%}
+      {%- assign content = subnote.content | strip_html | strip_newlines | escape -%}
+      {%- assign notes = notes | push: content -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- when 'note_singlepart' -%}
+  {%- assign content = note.content | strip_html | strip_newlines | escape -%}
+  {%- assign notes = notes | push: content -%}
+{%- endcase -%}

--- a/search_data.json
+++ b/search_data.json
@@ -14,21 +14,24 @@ layout: null
       {%- assign subjects = subjects | push: obj.title -%}
     {%- endfor -%}
 
-    {% case {{note.jsonmodel_type}} %}
-    {% when 'note_multipart' %}
-      {% for subnote in note.subnotes %}
-        {% if subnote.jsonmodel_type == 'note_text' %}
-          {{ subnote.content | markdownify }}
-        {% endif %}
-        {% if subnote.jsonmodel_type == 'note_chronology' %}
-          {% for item in subnote.items %}
-            {{item.event_date}}{% for event in item.events %}{{event}}{% endfor %}
-          {% endfor %}
-        {% endif %}
-      {% endfor %}
-    {% when 'note_singlepart' %}
-      {{ note.content }}
-    {% endcase %}
+    {%- for note in object.notes -%}
+      {%- assign label = note.label -%}
+      {% case {{note.jsonmodel_type}} %}
+      {% when 'note_multipart' %}
+        {% for subnote in note.subnotes %}
+          {% if subnote.jsonmodel_type == 'note_text' %}
+            {%- assign content = subnote.content -%}
+          {% endif %}
+          {% if subnote.jsonmodel_type == 'note_chronology' %}
+            {% for item in subnote.items %}
+              {{item.event_date}}{% for event in item.events %}{{event}}{% endfor %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      {% when 'note_singlepart' %}
+        {{ note.content }}
+      {% endcase %}
+    {%- endfor -%}
 
     {%- assign agents = "" | split: ',' -%}
     {%- for agent in object.linked_agents -%}

--- a/search_data.json
+++ b/search_data.json
@@ -6,15 +6,31 @@ layout: null
     {%- assign object = item_hash[1] -%}
     {%- assign id = item_hash[0] -%}
     {%- assign collection_id = object.uri | split:'/' | last -%}
-    {%- assign subjects = "" | split: '/' -%}
-    {%- assign agents = "" | split: '/' -%}
 
+    {%- assign subjects = "" | split: ',' -%}
     {%- for subject in object.subjects -%}
       {%- capture subject_id -%}{{ subject.ref | split: '/' | last }}{%- endcapture -%}
       {%- assign obj = site.data.subject[subject_id] -%}
       {%- assign subjects = subjects | push: obj.title -%}
     {%- endfor -%}
 
+    {% case {{note.jsonmodel_type}} %}
+    {% when 'note_multipart' %}
+      {% for subnote in note.subnotes %}
+        {% if subnote.jsonmodel_type == 'note_text' %}
+          {{ subnote.content | markdownify }}
+        {% endif %}
+        {% if subnote.jsonmodel_type == 'note_chronology' %}
+          {% for item in subnote.items %}
+            {{item.event_date}}{% for event in item.events %}{{event}}{% endfor %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    {% when 'note_singlepart' %}
+      {{ note.content }}
+    {% endcase %}
+
+    {%- assign agents = "" | split: ',' -%}
     {%- for agent in object.linked_agents -%}
       {%- capture agent_id -%}{{ agent.ref | split: '/' | last }}{%- endcapture -%}
       {%- if agent.ref contains "corporate_entities" -%}
@@ -26,11 +42,13 @@ layout: null
       {%- endif -%}
     {%- endfor -%}
 
+    {%- assign call_numbers = "" | split: ',' -%}
     {% for instance in object.instances %}
       {%- capture top_container_id -%}
         {{ instance.sub_container.top_container.ref | split: '/' | last }}
       {%- endcapture -%}
       {%- assign obj = site.data.top_container[top_container_id] -%}
+      {%- assign call_numbers = call_numbers | push: obj.indicator -%}
     {%- endfor -%}
 
     "resource/{{id}}": {
@@ -38,7 +56,8 @@ layout: null
       "title": "{{object.title | escape | strip_newlines | remove: '\'}}",
       "url": "{{site.url}}/resource/{{id}}",
       "agents": "{{ agents | join: ' | ' }}",
-      "subjects": "{{ subjects| join: ' | ' }}",
+      "subjects": "{{ subjects | join: ' | ' }}",
+      "call_numbers": "{{ call_numbers | uniq | join ' | '}}"
     }{%- unless forloop.last -%},{%- endunless -%}
   {%- endfor -%}
 }

--- a/search_data.json
+++ b/search_data.json
@@ -12,11 +12,12 @@ layout: null
       {%- capture agent_id -%}{{ agent.ref | split: '/' | last }}{%- endcapture -%}
       {%- if agent.ref contains "corporate_entities" -%}
         {%- assign agent_data = site.data.agent_corporate_entity[agent_id] -%}
-        {%- assign agents = agents | push: agent_data.title -%}
       {%- elsif agent.ref contains "people" -%}
         {%- assign agent_data = site.data.agent_person[agent_id] -%}
-        {%- assign agents = agents | push: agent_data.title -%}
+      {%- elsif agent.ref contains "family" -%}
+        {%- assign agent_data = site.data.agent_family[agent_id] -%}
       {%- endif -%}
+      {%- assign agents = agents | push: agent_data.title -%}
     {%- endfor -%}
 
     {%- assign subjects = "" | split: ',' -%}
@@ -28,38 +29,18 @@ layout: null
 
     {%- assign notes = "" | split: ',' -%}
     {%- for note in object.notes -%}
-      {%- assign label = note.label -%}
-      {% case {{note.jsonmodel_type}} %}
-      {% when 'note_multipart' %}
-        {% for subnote in note.subnotes %}
-          {% if subnote.jsonmodel_type == 'note_text' %}
-            {%- assign content = subnote.content -%}
-          {% endif %}
-        {% endfor %}
-      {% when 'note_singlepart' %}
-        {%- assign content = note.content -%}
-      {% endcase %}
-      {%- capture combined_note -%}{{ label }}:{{ content }}{%- endcapture -%}
-      {%- assign notes = notes | push: combined_note -%}
+      {%- include note_content.html -%}
     {%- endfor -%}
 
-    {%- assign call_numbers = "" | split: ',' -%}
-    {% for instance in object.instances %}
-      {%- capture top_container_id -%}
-        {{ instance.sub_container.top_container.ref | split: '/' | last }}
-      {%- endcapture -%}
-      {%- assign obj = site.data.top_container[top_container_id] -%}
-      {%- assign call_numbers = call_numbers | push: obj.indicator -%}
-    {%- endfor -%}
+    {%- include call_numbers.html -%}
 
     "resource/{{id}}": {
-      "href": "resource/{{id}}",
       "title": "{{object.title | escape | strip_newlines | remove: '\'}}",
       "url": "{{site.url}}/resource/{{id}}",
-      "agents": "{{ agents | join: ' | ' }}",
-      "subjects": "{{ subjects | join: ' | ' }}",
+      "agents": "{{ agents | join: ', ' }}",
+      "subjects": "{{ subjects | join: ', ' }}",
       "notes": "{{ notes | join: ', '}}",
-      "call_numbers": "{{ call_numbers | uniq | join ' | '}}"
+      "call_numbers": "{{ call_numbers | uniq | join: ', ' }}"
     }{%- unless forloop.last -%},{%- endunless -%}
   {%- endfor -%}
 }

--- a/search_data.json
+++ b/search_data.json
@@ -2,7 +2,7 @@
 layout: null
 ---
 {
-  {%- for item_hash in site.data.resource -%}
+  {% for item_hash in site.data.resource %}
     {%- assign object = item_hash[1] -%}
     {%- assign id = item_hash[0] -%}
     {%- assign collection_id = object.uri | split:'/' | last -%}
@@ -34,13 +34,12 @@ layout: null
 
     {%- include call_numbers.html -%}
 
-    "resource/{{id}}": {
-      "title": "{{object.title | escape | strip_newlines | remove: '\'}}",
+  "resource/{{id}}": {
+      "title": "{{ object.title | escape | strip_newlines | remove: '\' }}",
       "url": "{{site.url}}/resource/{{id}}",
       "agents": "{{ agents | join: ', ' }}",
       "subjects": "{{ subjects | join: ', ' }}",
       "notes": "{{ notes | join: ', '}}",
-      "call_numbers": "{{ call_numbers | uniq | join: ', ' }}"
-    }{%- unless forloop.last -%},{%- endunless -%}
-  {%- endfor -%}
-}
+      "call_numbers": "{{ call_numbers | uniq | join: ', ' }}"}{%- unless forloop.last -%},
+  {% endunless %}
+{% endfor %} }

--- a/search_data.json
+++ b/search_data.json
@@ -2,49 +2,43 @@
 layout: null
 ---
 {
-  {% for item_hash in data.resource %}
-    {% assign object = item_hash[1] %}
-    {% assign id = item_hash[0] %}
-    {% assign collection_id = object.uri | split:'/' | last %}
-    {% assign subjects = "" | split: ',' %}
-    {% assign agents = "" | split: ',' %}
-    {% assign dates = "" | split: ',' %}
+  {%- for item_hash in site.data.resource -%}
+    {%- assign object = item_hash[1] -%}
+    {%- assign id = item_hash[0] -%}
+    {%- assign collection_id = object.uri | split:'/' | last -%}
+    {%- assign subjects = "" | split: '/' -%}
+    {%- assign agents = "" | split: '/' -%}
 
-    {% for date in object.dates %}
-      {% assign dates = dates | push: date.expression %}
-    {% endfor %}
+    {%- for subject in object.subjects -%}
+      {%- capture subject_id -%}{{ subject.ref | split: '/' | last }}{%- endcapture -%}
+      {%- assign obj = site.data.subject[subject_id] -%}
+      {%- assign subjects = subjects | push: obj.title -%}
+    {%- endfor -%}
 
-    {% for subject in object.subjects %}
-      {% capture subject_id %}{{ subject.ref | split: '/' | last }}{% endcapture %}
-      {% assign obj = site.data.subject[subject_id] %}
-      {% assign subjects = subjects | push: obj.title %}
-    {% endfor %}
-
-    {% for agent in object.linked_agents %}
-      {% capture agent_id %}{{ agent.ref | split: '/' | last }}{% endcapture %}
-      {% if agent.ref contains "corporate_entities" %}
-        {% assign agent_data = site.data.agent_corporate_entity[agent_id] %}
-        {% assign agents = agents | push: agent_data.title %}
-      {% elsif agent.ref contains "people" %}
-        {% assign agent_data = site.data.agent_person[agent_id] %}
-        {% assign agents = agents | push: agent_data.title %}
-      {% endif %}
-    {% endfor %}
+    {%- for agent in object.linked_agents -%}
+      {%- capture agent_id -%}{{ agent.ref | split: '/' | last }}{%- endcapture -%}
+      {%- if agent.ref contains "corporate_entities" -%}
+        {%- assign agent_data = site.data.agent_corporate_entity[agent_id] -%}
+        {%- assign agents = agents | push: agent_data.title -%}
+      {%- elsif agent.ref contains "people" -%}
+        {%- assign agent_data = site.data.agent_person[agent_id] -%}
+        {%- assign agents = agents | push: agent_data.title -%}
+      {%- endif -%}
+    {%- endfor -%}
 
     {% for instance in object.instances %}
       {%- capture top_container_id -%}
         {{ instance.sub_container.top_container.ref | split: '/' | last }}
       {%- endcapture -%}
-      {% assign obj = site.data.top_container[top_container_id] %}
-    {% endfor %}
+      {%- assign obj = site.data.top_container[top_container_id] -%}
+    {%- endfor -%}
 
     "resource/{{id}}": {
       "href": "resource/{{id}}",
       "title": "{{object.title | escape | strip_newlines | remove: '\'}}",
       "url": "{{site.url}}/resource/{{id}}",
-      "dates": "{{ dates }}",
-      "agents": "{{ agents }}",
-      "subjects": "{{ subjects }}",
-    }{% unless forloop.last %},{% endunless %}
-  {% endfor %}
+      "agents": "{{ agents | join: ' | ' }}",
+      "subjects": "{{ subjects| join: ' | ' }}",
+    }{%- unless forloop.last -%},{%- endunless -%}
+  {%- endfor -%}
 }

--- a/search_data.json
+++ b/search_data.json
@@ -7,32 +7,6 @@ layout: null
     {%- assign id = item_hash[0] -%}
     {%- assign collection_id = object.uri | split:'/' | last -%}
 
-    {%- assign subjects = "" | split: ',' -%}
-    {%- for subject in object.subjects -%}
-      {%- capture subject_id -%}{{ subject.ref | split: '/' | last }}{%- endcapture -%}
-      {%- assign obj = site.data.subject[subject_id] -%}
-      {%- assign subjects = subjects | push: obj.title -%}
-    {%- endfor -%}
-
-    {%- for note in object.notes -%}
-      {%- assign label = note.label -%}
-      {% case {{note.jsonmodel_type}} %}
-      {% when 'note_multipart' %}
-        {% for subnote in note.subnotes %}
-          {% if subnote.jsonmodel_type == 'note_text' %}
-            {%- assign content = subnote.content -%}
-          {% endif %}
-          {% if subnote.jsonmodel_type == 'note_chronology' %}
-            {% for item in subnote.items %}
-              {{item.event_date}}{% for event in item.events %}{{event}}{% endfor %}
-            {% endfor %}
-          {% endif %}
-        {% endfor %}
-      {% when 'note_singlepart' %}
-        {{ note.content }}
-      {% endcase %}
-    {%- endfor -%}
-
     {%- assign agents = "" | split: ',' -%}
     {%- for agent in object.linked_agents -%}
       {%- capture agent_id -%}{{ agent.ref | split: '/' | last }}{%- endcapture -%}
@@ -43,6 +17,30 @@ layout: null
         {%- assign agent_data = site.data.agent_person[agent_id] -%}
         {%- assign agents = agents | push: agent_data.title -%}
       {%- endif -%}
+    {%- endfor -%}
+
+    {%- assign subjects = "" | split: ',' -%}
+    {%- for subject in object.subjects -%}
+      {%- capture subject_id -%}{{ subject.ref | split: '/' | last }}{%- endcapture -%}
+      {%- assign obj = site.data.subject[subject_id] -%}
+      {%- assign subjects = subjects | push: obj.title -%}
+    {%- endfor -%}
+
+    {%- assign notes = "" | split: ',' -%}
+    {%- for note in object.notes -%}
+      {%- assign label = note.label -%}
+      {% case {{note.jsonmodel_type}} %}
+      {% when 'note_multipart' %}
+        {% for subnote in note.subnotes %}
+          {% if subnote.jsonmodel_type == 'note_text' %}
+            {%- assign content = subnote.content -%}
+          {% endif %}
+        {% endfor %}
+      {% when 'note_singlepart' %}
+        {%- assign content = note.content -%}
+      {% endcase %}
+      {%- capture combined_note -%}{{ label }}:{{ content }}{%- endcapture -%}
+      {%- assign notes = notes | push: combined_note -%}
     {%- endfor -%}
 
     {%- assign call_numbers = "" | split: ',' -%}
@@ -60,6 +58,7 @@ layout: null
       "url": "{{site.url}}/resource/{{id}}",
       "agents": "{{ agents | join: ' | ' }}",
       "subjects": "{{ subjects | join: ' | ' }}",
+      "notes": "{{ notes | join: ', '}}",
       "call_numbers": "{{ call_numbers | uniq | join ' | '}}"
     }{%- unless forloop.last -%},{%- endunless -%}
   {%- endfor -%}

--- a/search_data.json
+++ b/search_data.json
@@ -1,0 +1,50 @@
+---
+layout: null
+---
+{
+  {% for item_hash in data.resource %}
+    {% assign object = item_hash[1] %}
+    {% assign id = item_hash[0] %}
+    {% assign collection_id = object.uri | split:'/' | last %}
+    {% assign subjects = "" | split: ',' %}
+    {% assign agents = "" | split: ',' %}
+    {% assign dates = "" | split: ',' %}
+
+    {% for date in object.dates %}
+      {% assign dates = dates | push: date.expression %}
+    {% endfor %}
+
+    {% for subject in object.subjects %}
+      {% capture subject_id %}{{ subject.ref | split: '/' | last }}{% endcapture %}
+      {% assign obj = site.data.subject[subject_id] %}
+      {% assign subjects = subjects | push: obj.title %}
+    {% endfor %}
+
+    {% for agent in object.linked_agents %}
+      {% capture agent_id %}{{ agent.ref | split: '/' | last }}{% endcapture %}
+      {% if agent.ref contains "corporate_entities" %}
+        {% assign agent_data = site.data.agent_corporate_entity[agent_id] %}
+        {% assign agents = agents | push: agent_data.title %}
+      {% elsif agent.ref contains "people" %}
+        {% assign agent_data = site.data.agent_person[agent_id] %}
+        {% assign agents = agents | push: agent_data.title %}
+      {% endif %}
+    {% endfor %}
+
+    {% for instance in object.instances %}
+      {%- capture top_container_id -%}
+        {{ instance.sub_container.top_container.ref | split: '/' | last }}
+      {%- endcapture -%}
+      {% assign obj = site.data.top_container[top_container_id] %}
+    {% endfor %}
+
+    "resource/{{id}}": {
+      "href": "resource/{{id}}",
+      "title": "{{object.title | escape | strip_newlines | remove: '\'}}",
+      "url": "{{site.url}}/resource/{{id}}",
+      "dates": "{{ dates }}",
+      "agents": "{{ agents }}",
+      "subjects": "{{ subjects }}",
+    }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+}


### PR DESCRIPTION
Adds search index data.

Currently a little stuck on how to deal with notes in a systematic manner. There are a huge variety, and I'm not sure we'd need all of them. I figure Publication and ISBN maybe? Additionally, I'm not quite sure how to capture them with the proper title/content as for the others, I'm basically just writing strings to an array in liquid.

Additionally, a little stumped on how to work with top containers. We really only want these for the call number, which is in the indicator. Some library resources have multiple top containers, but not all of them have the call number (I think), and some are multiple top containers with the same call number... See https://dimes.rockarch.org/xtf/view?docId=mods/LI03963/LI03963.xml;query=;chunk.id=headerlink;brand=default and https://dimes.rockarch.org/xtf/view?docId=mods/LI07343/LI07343.xml;query=;chunk.id=headerlink;brand=default as examples.

Some guidance on whether what I have is the correct approach for this, and how to handle top containers/notes would be appreciated