### PR TITLE
escape double quotes

### DIFF
--- a/script/make_pages.py
+++ b/script/make_pages.py
@@ -10,7 +10,7 @@ PAGE_DIR = abspath(join(__file__, pardir, pardir, OBJ_PREFIX))
 
 
 def clean_string(string):
-    return string.strip().replace("\n", "")
+    return string.strip().replace("\n", "").replace('"', '\\"')
 
 
 def make_pages():


### PR DESCRIPTION
Quick fix for double quotes in titles. Replaces `"` with `\"`.