### PR TITLE
Fix author display in items by making them into an actual array.

### DIFF
--- a/_includes/author_list.html
+++ b/_includes/author_list.html
@@ -3,4 +3,4 @@
   {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
   {%- assign authors = authors | push: agent_title -%}
 {%- endfor -%}
-{{- authors | join: '<' -}}
+{{- authors | join: ', '-}}

--- a/_includes/author_list.html
+++ b/_includes/author_list.html
@@ -3,4 +3,4 @@
   {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
   {%- assign authors = authors | push: agent_title -%}
 {%- endfor -%}
-{{- authors -}}
+{{- authors | join: '<' -}}

--- a/_layouts/item.html
+++ b/_layouts/item.html
@@ -25,11 +25,9 @@ layout: default
   <div class="wrapper">
     <div class="container item__attribute">
       <h2 class="item-details__label">Authors</h2>
-      {% capture author_list %}{% include author_list.html %}{% endcapture %}
-      {%- assign author_list = author_list | split: '<' -%}
       <ul class="list--unstyled">
-      {% for author in author_list %}
-        <li>{{author}}</li>
+      {% for agent in object.linked_agents %}
+        <li>{%- include linked_agent_title.html agent=agent -%}</li>
       {% endfor %}
       </ul>
     </div>

--- a/_layouts/item.html
+++ b/_layouts/item.html
@@ -26,6 +26,7 @@ layout: default
     <div class="container item__attribute">
       <h2 class="item-details__label">Authors</h2>
       {% capture author_list %}{% include author_list.html %}{% endcapture %}
+      {%- assign author_list = author_list | split: '<' -%}
       <ul class="list--unstyled">
       {% for author in author_list %}
         <li>{{author}}</li>

--- a/search_data.json
+++ b/search_data.json
@@ -7,12 +7,6 @@ layout: null
     {%- assign id = item_hash[0] -%}
     {%- assign collection_id = object.uri | split:'/' | last -%}
 
-    {%- assign agents = "" | split: ',' -%}
-    {%- for agent in object.linked_agents -%}
-      {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
-      {%- assign agents = agents | push: agent_title -%}
-    {%- endfor -%}
-
     {%- assign subjects = "" | split: ',' -%}
     {%- for subject in object.subjects -%}
       {%- capture subject_id -%}{{ subject.ref | split: '/' | last }}{%- endcapture -%}
@@ -31,7 +25,7 @@ layout: null
   "/items/{{id}}/": {
       "title": "{{ object.title | escape | strip_newlines | remove: '\' }}",
       "url": "{{site.url}}/item/{{id}}",
-      "agents": "{{ agents | join: ', ' }}",
+      "agents": "{%- include author_list.html -%}",
       "subjects": "{{ subjects | join: ', ' }}",
       "notes": "{{- notes | join: ', ' | strip_newlines | strip_html | escape -}}",
       "call_numbers": "{{ call_numbers | uniq | join: ', ' }}"}{%- unless forloop.last -%},


### PR DESCRIPTION
So, while fiddling with index stuff, I noticed that the resources with multiple authors weren't displaying properly.

I tracked it down to the fact that `capture` only captures as a string, and that string didn't have any separators in it...

So, I made `author_list.html` return a string out of the authors array joined by '<', then captured the include, then split that captured variable to make it _back_ into an array.

This is all complicated because you for some reason can't use `assign` and an include in liquid. For sure let me know if you know of a better way.

