### PR TITLE
Correctly routes creator and subject agents and changes item display

### DIFF
--- a/_includes/author_list.html
+++ b/_includes/author_list.html
@@ -1,6 +1,8 @@
 {%- assign authors = "" | split: ',' -%}
 {%- for agent in object.linked_agents -%}
-  {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
-  {%- assign authors = authors | push: agent_title -%}
+  {% if agent.role == "creator" %}
+    {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
+    {%- assign authors = authors | push: agent_title -%}
+  {% endif %}
 {%- endfor -%}
 {{- authors | join: ', ' | strip_newlines | escape -}}

--- a/_includes/linked_agent_title.html
+++ b/_includes/linked_agent_title.html
@@ -3,5 +3,7 @@
   {%- assign agent_data = site.data.agent_corporate_entity[agent_id] -%}
 {%- elsif agent.ref contains "people" -%}
   {%- assign agent_data = site.data.agent_person[agent_id] -%}
+{%- elsif agent.ref contains "family" -%}
+  {%- assign agent_data = site.data.agent_family[agent_id] -%}
 {%- endif -%}
 {{- agent_data.title -}}

--- a/_includes/subject_list.html
+++ b/_includes/subject_list.html
@@ -2,6 +2,12 @@
 {% for subject in object.subjects %}
   {% capture subject_id %}{{ subject.ref | split: "/" | last }}{% endcapture %}
   {% assign obj = site.data.subject[subject_id] %}
-  <li>{{obj.title}}</li>
+  <li>{{obj.title | strip_newlines | escape}}</li>
 {% endfor %}
+{%- for agent in object.linked_agents -%}
+  {% if agent.role == "subject" %}
+    {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
+    <li>{{agent_title | strip_newlines | escape}}</li>
+  {% endif %}
+{%- endfor -%}
 </ul>

--- a/_layouts/item.html
+++ b/_layouts/item.html
@@ -26,11 +26,14 @@ layout: default
       <h2 class="item-details__label">Authors</h2>
       <ul class="list--unstyled">
       {% for agent in object.linked_agents %}
-        <li>{%- include linked_agent_title.html agent=agent -%}</li>
+        {% if agent.role == "creator" %}
+          <li>{%- include linked_agent_title.html agent=agent -%}</li>
+        {% endif %}
       {% endfor %}
       </ul>
     </div>
-    {% if object.subjects.size > 0 %}
+    {%- capture subjects -%}{%- include subject_list.html object=object -%}{%- endcapture -%}
+    {% if subjects.size > 0 %}
     <div class="container item__attribute">
       <h2 class="item-details__label">Subject Terms</h2>
       {% include subject_list.html object=object %}

--- a/search_data.json
+++ b/search_data.json
@@ -14,6 +14,16 @@ layout: null
       {%- assign subjects = subjects | push: obj.title -%}
     {%- endfor -%}
 
+    {%- assign subject_agents = "" | split: ',' -%}
+    {%- for agent in object.linked_agents -%}
+      {% if agent.role == "subject" %}
+        {%- capture agent_title -%}{%- include linked_agent_title.html agent=agent -%}{%- endcapture -%}
+        {%- assign subject_agents = subject_agents | push: agent_title -%}
+      {% endif %}
+    {%- endfor -%}
+
+    {%- assign subjects = subjects | concat: subject_agents -%}
+
     {%- assign notes = "" | split: ',' -%}
     {%- for note in object.notes -%}
       {%- capture content -%}{%- include note_content.html -%}{%- endcapture -%}
@@ -21,11 +31,11 @@ layout: null
     {%- endfor -%}
 
   "/items/{{id}}/": {
-      "title": "{{ object.title | escape | strip_newlines | remove: '\' }}",
+      "title": "{{- object.title | escape | strip_newlines | remove: '\' -}}",
       "ref": "/items/{{id}}/",
       "url": "{{site.url}}/items/{{id}}/",
       "author": "{%- include author_list.html -%}",
-      "subject": "{{- subjects | join: ', ' -}}",
+      "subject": "{{- subjects | join: ', ' | strip_newlines | escape -}}",
       "notes": "{{- notes | join: ', ' | strip_newlines | strip_html | strip | remove: '\' | escape -}}",
       "dates": "{%- include date_list.html -%}",
       "call_numbers": "{%- include call_numbers.html -%}"}{%- unless forloop.last -%},


### PR DESCRIPTION
Fixes #56 

Routes agents with the role of `creator` to the `author` field in search data, and agents with the `subject` role to the `subject` field.

Changes item display to only show creators under the Author tile and includes subject agents to the subject list. 

Not sure this is the _most_ correct solution, but works well for me with the sample data.