### PR TITLE
Remove login to raccess text

### DIFF
--- a/_includes/request_modal.html
+++ b/_includes/request_modal.html
@@ -28,7 +28,6 @@
               <label for="ScheduledDate">Scheduled date of visit*</label>
               <input type="date" id="ScheduledDate" name="ScheduledDate" required=required />
             </div>
-            <p class="modal__info">To track your requests, <a href="https://raccess.rockarch.org">login to RACcess</a></p>
             <div class="modal-form__buttons">
               <button type="submit" class="btn btn--orange btn--sm">Request Item</button>
               <button type="reset" class="btn btn--gray btn--sm" data-micromodal-close>Cancel</button>

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -131,7 +131,7 @@ h2:not(:first-child) {
   display: none;
   &.is-open {
     display: block;
-    height: 85%;
+    height: 100%;
     width: 100%;
     background: rgba(0, 0, 0, 0.15);
     position: fixed;

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -131,7 +131,7 @@ h2:not(:first-child) {
   display: none;
   &.is-open {
     display: block;
-    height: 100%;
+    height: 85%;
     width: 100%;
     background: rgba(0, 0, 0, 0.15);
     position: fixed;

--- a/_sass/rac/components/_modal.scss
+++ b/_sass/rac/components/_modal.scss
@@ -1,9 +1,5 @@
 @import "../styles";
 
-.modal__info a{
-  text-decoration: underline;
-}
-
 .modal-overlay {
   position: fixed;
   top: 0px;
@@ -86,6 +82,7 @@
 .modal-form__input  {
   font-size: 14px;
   margin-bottom: 18px;
+  padding: 20px 0px;
   & label {
     margin-bottom: 5px;
     float: left;


### PR DESCRIPTION
Removes login to raccess text from request modal.

Additionally, reduces the size of the modal given less content.

Fixes #74 