### PR TITLE
Improves HTML structure and styling for search tiles

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -191,10 +191,26 @@ h2:not(:first-child) {
   flex-wrap: wrap;
 }
 
+.tile {
+  position: relative;
+}
+
 .tile__title {
   border-bottom: none;
   padding-bottom: 0;
   margin-bottom: 0;
+  &:hover {
+    text-decoration: none;
+    color: $dark-gray;
+  }
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
 }
 
 .tile__authors, .tile__callnumber {

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -193,16 +193,23 @@ h2:not(:first-child) {
 
 .tile {
   position: relative;
+  min-height: 120px;
+  @media screen and (min-width: $break-lg) {
+    min-height: 130px;
+  }
 }
 
 .tile__title {
   border-bottom: none;
   padding-bottom: 0;
-  margin-bottom: 0;
-  &:hover {
-    text-decoration: none;
-    color: $dark-gray;
-  }
+  margin: 0;
+}
+
+.tile__link {
+  min-height: 0;
+  font-size: inherit;
+  font-family: inherit;
+  color: $dark-gray;
   &::before {
     content: "";
     position: absolute;
@@ -210,6 +217,10 @@ h2:not(:first-child) {
     bottom: 0;
     left: 0;
     right: 0;
+  }
+  &:hover {
+    text-decoration: none;
+    color: $dark-gray;
   }
 }
 

--- a/js/search.js
+++ b/js/search.js
@@ -9,7 +9,9 @@ $(document).ready(function() {
           let item = documents[results[r].ref];
           appendString +=
             `<li class="tile">
-              <a class="tile__title" href="${item.url}">${item.title}</a>
+              <h2 class="tile__title">
+                <a class="tile__link" href="${item.url}">${item.title}</a>
+              </h2>
               <p class="tile__callnumber">${item.call_numbers}</p>
               <p class="tile__authors"><strong>Author(s)</strong>: ${item.author}</p>
               <p class="tile__date"><strong>Published</strong>: ${item.dates}</p>

--- a/js/search.js
+++ b/js/search.js
@@ -9,12 +9,10 @@ $(document).ready(function() {
           let item = documents[results[r].ref];
           appendString +=
             `<li class="tile">
-              <a class="tile__link" href="${item.url}">
-                <h2 class="tile__title">${item.title}</h2>
-                <p class="tile__callnumber">${item.call_numbers}</p>
-                <p class="tile__authors"><strong>Author(s)</strong>: ${item.author}</p>
-                <p class="tile__date"><strong>Published</strong>: ${item.dates}</p>
-              </a>
+              <a class="tile__title" href="${item.url}">${item.title}</a>
+              <p class="tile__callnumber">${item.call_numbers}</p>
+              <p class="tile__authors"><strong>Author(s)</strong>: ${item.author}</p>
+              <p class="tile__date"><strong>Published</strong>: ${item.dates}</p>
             </li>`;
         }
         appendString += '</ul>'


### PR DESCRIPTION
Wraps only the search tile title in a link, and improves styling so entire tile is clickable.

fixes #70