### PR TITLE
Remove jekyll-feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ gem "jekyll"
 gem "html-proofer"
 
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.9"
   gem "neat", "~> 4.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,8 +39,6 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
-    jekyll-feed (0.15.0)
-      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,6 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll
-  jekyll-feed (~> 0.9)
   neat (~> 4.0.0)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -14,9 +14,6 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: rockarch_org
 github_username:  RockefellerArchiveCenter
 
-plugins:
-  - jekyll-feed
-
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-NQRWDJK');</script>
   <!-- End Google Tag Manager -->
-  
+
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -16,5 +16,4 @@
 
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/img/favicon.ico">


### PR DESCRIPTION
Removes jekyll-feed components. Fixes #66 

Didn't see great performance gains on small amount of pages, but we should definitely remove it if we're not going to make use of it.