### PR TITLE
Fixes stopword requirement

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -69,7 +69,7 @@ $(document).ready(function() {
     }
     else {
       var processedTerm = searchField.length ? `${searchField}:${processed}` : processed
-      return stopWords.includes(processed) ? `${processedTerm}` : `+${processedTerm}`
+      return stopWords.includes(processed.replace('~1', '')) ? `${processedTerm}` : `+${processedTerm}`
     }
   }
 

--- a/js/search.js
+++ b/js/search.js
@@ -63,13 +63,15 @@ $(document).ready(function() {
   * handles stop words, adds boolean AND, and fuzzy matching
   */
   function preProcessQueryTerm(term) {
-    const processed = term.replace(/:|"|'|~|\^/g, "").concat("~1")
-    if (!processed) {
+    const charsRemoved = term.replace(/:|"|'|~|\^/g, "")
+    const fuzzyDistance = 1
+    const fuzzyTerm = charsRemoved.concat(`~${fuzzyDistance}`)
+    if (!charsRemoved) {
       return null
     }
     else {
-      var processedTerm = searchField.length ? `${searchField}:${processed}` : processed
-      return stopWords.includes(processed.replace('~1', '')) ? `${processedTerm}` : `+${processedTerm}`
+      const targetedTerm = searchField.length ? `${searchField}:${fuzzyTerm}` : fuzzyTerm
+      return stopWords.includes(charsRemoved) ? `${targetedTerm}` : `+${targetedTerm}`
     }
   }
 


### PR DESCRIPTION
Removes the `~1` from the end of `processed` in search.js so it actually matches against stopwords. Fixes #92 

Should be noted that it does make searches a little less exact when included because it's adding that word as an `OR` search, but I'm not sure the best solution for that.