### PR TITLE
Removes html-proofer version from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2.0"
-gem "html-proofer", "~> 3.19.2"
+gem "html-proofer"
 
 group :jekyll_plugins do
   gem "neat", "~> 4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.19.2)
+  html-proofer
   jekyll (~> 4.2.0)
   neat (~> 4.0.0)
 


### PR DESCRIPTION
Amplify can't deploy with most up to date html-proofer version. Removing version specification from Gemfile.