### PR TITLE
Replacing GTM code with MTM code 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,12 +1,14 @@
 <head>
-  <!-- Google Tag Manager -->
   {%- if jekyll.environment == "production" -%}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NQRWDJK');</script>
-    <!-- End Google Tag Manager -->
+  <!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_iXvhddJ4.js'; s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
+    
   {%- endif -%}
 
   <meta charset="utf-8">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,16 +1,12 @@
 <head>
-  {%- if jekyll.environment == "production" -%}
-  <!-- Matomo Tag Manager -->
+ <!-- Matomo Tag Manager -->
 <script>
 var _mtm = window._mtm = window._mtm || [];
 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_iXvhddJ4.js'; s.parentNode.insertBefore(g,s);
+g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_SdzKujX7_dev_cc9545323ac9afaa195e6699.js'; s.parentNode.insertBefore(g,s);
 </script>
 <!-- End Matomo Tag Manager -->
-    
-  {%- endif -%}
-
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 var _mtm = window._mtm = window._mtm || [];
 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_SdzKujX7_dev_cc9545323ac9afaa195e6699.js'; s.parentNode.insertBefore(g,s);
+g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_SdzKujX7.js'; s.parentNode.insertBefore(g,s);
 </script>
 <!-- End Matomo Tag Manager -->
   <meta charset="utf-8">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,10 +3,6 @@
 <html>
   {% include head.html %}
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript aria-hidden="true"><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NQRWDJK"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <nav>
       <a href="#main" class="skip-link visually-hidden">Jump directly to main content</a>
     </nav>


### PR DESCRIPTION
Replacing Google Tag Manager code and any other Google Analytics code with Matomo Tag Manager code on the library discovery website. 